### PR TITLE
[dev] Update bottom sheet and fix avatar component size prop

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -280,7 +280,7 @@ export const App: React.FC<IProps> = (): React.ReactElement => {
 
   const redDotMarker = (
     // eslint-disable-next-line react-native/no-inline-styles
-    <View style={{width: '100%', height: '100%', backgroundColor: 'red'}} />
+    <View style={{width: 12, height: 12, backgroundColor: 'red'}} />
   );
 
   return (
@@ -317,10 +317,10 @@ export const App: React.FC<IProps> = (): React.ReactElement => {
                 <Avatar uri={avatarUri} />
               </Row>
               <Row>
-                <Avatar uri={avatarUri} marker={redDotMarker} />
+                <Avatar uri={undefined} />
               </Row>
               <Row>
-                <Avatar uri={undefined} />
+                <Avatar uri={avatarUri} marker={redDotMarker} />
               </Row>
               <Row>
                 <Avatar uri={undefined} marker={redDotMarker} />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### v0.0.27
+
+- Prop size affects the size of the Icon
+- Refactor BottomSheet component
+
+---
+
+### v0.0.26
+
+- Add size prop on Avatar component
+- Add appearance and dimension utility functions
+
+---
+
 ### v0.0.25
 
 - Add size prop on Avatar component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
 
 ### v0.0.26
 
-- Add size prop on Avatar component
-- Add appearance and dimension utility functions
+- Allow changing height of Tiles using the height property
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-mobile-app-ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/src/modules/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/src/modules/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -16,11 +16,11 @@ exports[`Avatar Rendering renders correctly 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "height": 33,
+      "height": 32,
       "justifyContent": "center",
       "opacity": 1,
       "overflow": "hidden",
-      "width": 33,
+      "width": 32,
     }
   }
   testID="avatar-button"
@@ -35,7 +35,7 @@ exports[`Avatar Rendering renders correctly 1`] = `
       Array [
         Object {
           "borderColor": "#FFFFFF",
-          "borderRadius": 33,
+          "borderRadius": 32,
           "borderWidth": 1,
           "height": "100%",
           "width": "100%",
@@ -63,11 +63,11 @@ exports[`Avatar Rendering renders the passed marker correctly 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "height": 33,
+      "height": 32,
       "justifyContent": "center",
       "opacity": 1,
       "overflow": "hidden",
-      "width": 33,
+      "width": 32,
     }
   }
   testID="avatar-button"
@@ -82,7 +82,7 @@ exports[`Avatar Rendering renders the passed marker correctly 1`] = `
       Array [
         Object {
           "borderColor": "#FFFFFF",
-          "borderRadius": 33,
+          "borderRadius": 32,
           "borderWidth": 1,
           "height": "100%",
           "width": "100%",
@@ -96,12 +96,10 @@ exports[`Avatar Rendering renders the passed marker correctly 1`] = `
       Array [
         Object {
           "borderRadius": 12,
-          "bottom": -1,
-          "height": 12,
+          "bottom": 0,
           "overflow": "hidden",
           "position": "absolute",
-          "right": -1,
-          "width": 12,
+          "right": 0,
         },
       ]
     }

--- a/src/modules/avatar/avatar.tsx
+++ b/src/modules/avatar/avatar.tsx
@@ -29,7 +29,6 @@ const StyledImage = Styled.Image<IStyledImage>`
 `;
 const StyledMarker = Styled.View<IStyledMarker>`
   position: absolute;
-  width: 12px; height: 12px;
   bottom: ${({$offsetBottom}) => $offsetBottom}px;
   right: ${({$offsetRight}) => $offsetRight}px;
   border-radius: 12px;
@@ -40,16 +39,16 @@ const StyledMarker = Styled.View<IStyledMarker>`
 export const Avatar: React.FC<IProps> = ({
   uri,
   onPress,
-  markerOffsetRight = -1,
-  markerOffsetBottom = -1,
+  markerOffsetRight = 0,
+  markerOffsetBottom = 0,
   inversed = false,
-  size = 33,
+  size = 32,
   marker,
 }): React.ReactElement => {
   return (
     <StyledWrapper
       $size={size}
-      activeOpacity={1}
+      activeOpacity={0.75}
       onPress={onPress}
       testID="avatar-button">
       {uri ? (
@@ -71,7 +70,7 @@ export const Avatar: React.FC<IProps> = ({
         </React.Fragment>
       ) : (
         <React.Fragment>
-          <Icon type="user" color={inversed ? 'white' : 'black'} size={33} />
+          <Icon type="user" color={inversed ? 'white' : 'black'} size={size} />
 
           {marker ? (
             <StyledMarker

--- a/src/modules/bottom-sheet/bottom-sheet.tsx
+++ b/src/modules/bottom-sheet/bottom-sheet.tsx
@@ -79,8 +79,8 @@ export const BottomSheet: React.FC<IProps> = ({
 
   // On Close Modal
   const onCloseModal = () => {
-    // Close the modal
-    modalRef.current.close();
+    // @ts-ignore
+    modalRef?.current?.close?.();
 
     // Call callback function
     onDismiss();
@@ -97,8 +97,7 @@ export const BottomSheet: React.FC<IProps> = ({
       useNativeDriverForBackdrop
       style={modalStyle}
       useNativeDriver
-      propagateSwipe
-      transparent>
+      propagateSwipe>
       <StyledWrapper>
         {/* Close Button */}
         {showCloseButton && (

--- a/src/modules/bottom-sheet/bottom-sheet.tsx
+++ b/src/modules/bottom-sheet/bottom-sheet.tsx
@@ -1,6 +1,6 @@
 // Modules
 import * as React from 'react';
-import {Animated, Dimensions, SafeAreaView} from 'react-native';
+import {SafeAreaView} from 'react-native';
 import Styled from 'styled-components/native';
 import Modal from 'react-native-modal';
 
@@ -14,22 +14,15 @@ import Heading from '../heading/heading';
 import {minorScale, majorScale} from '../scales';
 import {LayoutUtils} from '../utilities';
 
-// Constants
-const {height: SCREEN_HEIGHT} = Dimensions.get('screen');
-
 // Styles
 const StyledWrapper = Styled.View`
   width: 100%; height: 100%;
-  padding-top: ${majorScale(8)}px;
-  justify-content: flex-end;
-  flex: 1;
-`;
-const StyledContainer = Styled.View`
-  width: 100%; height: 100%;
-  background: ${({theme}) => theme.colors.white};
-  border-top-right-radius: 12px;
-  border-top-left-radius: 12px;
+  backgroundColor: ${({theme}) => theme.colors.white};
+  margin-top: ${majorScale(12)}px;
+  borderTopRightRadius: 12px;
+  borderTopLeftRadius: 12px;
   overflow: hidden;
+
 `;
 const StyledCloseWrapper = Styled.TouchableOpacity`
   position: absolute;
@@ -68,7 +61,9 @@ const StyledContentWrapper = Styled.View`
   justify-content: flex-start;
   flex: 1;
 `;
-const StyledFooterWrapper = Styled.View``;
+const StyledFooterWrapper = Styled.View`
+  margin-bottom: ${majorScale(8)}px;
+`;
 
 // Component
 export const BottomSheet: React.FC<IProps> = ({
@@ -79,94 +74,67 @@ export const BottomSheet: React.FC<IProps> = ({
   header,
   footer,
 }): React.ReactElement => {
-  // Animations
-  const animPanY = new Animated.Value(SCREEN_HEIGHT);
-  const animSlideUpContainer = Animated.timing(animPanY, {
-    duration: 400,
-    useNativeDriver: true,
-    toValue: 0,
-  });
-  const animSlideDownContainer = Animated.timing(animPanY, {
-    duration: 350,
-    toValue: SCREEN_HEIGHT,
-    useNativeDriver: true,
-  });
+  // Refs
+  const modalRef = React.useRef(null);
 
-  const _onDismiss = () => {
-    animSlideDownContainer.start(onDismiss);
+  // On Close Modal
+  const onCloseModal = () => {
+    // Close the modal
+    modalRef.current.close();
+
+    // Call callback function
+    onDismiss();
   };
-
-  React.useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        animSlideUpContainer.start();
-      }, 400);
-    } else {
-      animSlideDownContainer.start();
-    }
-  }, [isOpen]);
-
-  const translateY = animPanY.interpolate({
-    inputRange: [-1, 0, 1],
-    outputRange: [0, 0, 1],
-  });
 
   const modalStyle = {margin: 0};
 
   return (
     <Modal
-      coverScreen
-      hasBackdrop
-      propagateSwipe
-      useNativeDriver
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      onDismiss={_onDismiss}
-      onBackButtonPress={_onDismiss}
+      ref={modalRef}
       isVisible={isOpen}
-      style={modalStyle}>
+      onModalHide={onDismiss}
+      hideModalContentWhileAnimating
+      useNativeDriverForBackdrop
+      style={modalStyle}
+      useNativeDriver
+      propagateSwipe
+      transparent>
       <StyledWrapper>
-        <Animated.View style={{transform: [{translateY}]}}>
-          <StyledContainer>
-            {/* Close Button */}
-            {showCloseButton && (
-              <StyledCloseWrapper
-                activeOpacity={0.75}
-                hitSlop={LayoutUtils.addHitSlop(12)}
-                onPress={_onDismiss}>
-                <Icon type="closeCircle" color="muted" />
-              </StyledCloseWrapper>
-            )}
+        {/* Close Button */}
+        {showCloseButton && (
+          <StyledCloseWrapper
+            activeOpacity={0.75}
+            hitSlop={LayoutUtils.addHitSlop(12)}
+            onPress={onCloseModal}>
+            <Icon type="closeCircle" color="muted" />
+          </StyledCloseWrapper>
+        )}
 
-            {/* Sections */}
-            <StyledSectionWrapper>
-              {/* Header */}
-              {header?.title && (
-                <StyledHeader.Wrapper>
-                  <StyledHeader.Title variant="h3">
-                    {header.title}
-                  </StyledHeader.Title>
+        {/* Sections */}
+        <StyledSectionWrapper>
+          {/* Header */}
+          {header?.title && (
+            <StyledHeader.Wrapper>
+              <StyledHeader.Title variant="h3">
+                {header.title}
+              </StyledHeader.Title>
 
-                  {header?.description && (
-                    <StyledHeader.Description>
-                      {header.description}
-                    </StyledHeader.Description>
-                  )}
-                </StyledHeader.Wrapper>
+              {header?.description && (
+                <StyledHeader.Description>
+                  {header.description}
+                </StyledHeader.Description>
               )}
+            </StyledHeader.Wrapper>
+          )}
 
-              {/* Content */}
-              <StyledContentWrapper>{children}</StyledContentWrapper>
+          {/* Content */}
+          <StyledContentWrapper>{children}</StyledContentWrapper>
 
-              {/* Footer */}
-              {footer && (
-                <StyledFooterWrapper>
-                  <SafeAreaView>{footer()}</SafeAreaView>
-                </StyledFooterWrapper>
-              )}
-            </StyledSectionWrapper>
-          </StyledContainer>
-        </Animated.View>
+          {/* Footer */}
+          <StyledFooterWrapper>
+            <SafeAreaView>{footer}</SafeAreaView>
+          </StyledFooterWrapper>
+        </StyledSectionWrapper>
       </StyledWrapper>
     </Modal>
   );

--- a/src/modules/bottom-sheet/bottom-sheet.types.ts
+++ b/src/modules/bottom-sheet/bottom-sheet.types.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 // Header
 export interface IHeader {
   /** Title for the bottom sheet. */
@@ -21,6 +23,6 @@ export interface IProps {
   /** Header component of the bottom sheet. */
   header?: IHeader;
 
-  /** Function that renders a component as the footer of the bottom sheet. */
-  footer?: Function;
+  /** React element to be rendered as the footer. */
+  footer?: React.ReactElement;
 }


### PR DESCRIPTION
# Breaking Changes:

cc @raoufr @mdjacobs

## Avatar 

1. The `size` prop now affects the size of the icon too.
2. The `marker` component needs to specify a width and height instead of setting these values to 100%. 
3. The default value of `markerOffsetBottom` and `markerOffsetRight` props will now be `0` instead of `-1`.

### Example Usage

Now that the Avatar Icon and Image both can be resized, the marker would need to match the position and maintain its size.

```js
<Avatar
  ...
  marker={
    <Dot style={{ 
      width: 12,  // <----- Need to explicitly specify the width
      height: 12  // <----- Need to explicitly specify the height
    }} />
  }
/>
```

