### PR TITLE
Add typescript support in build

### DIFF
--- a/.github/workflows/tests-build.yml
+++ b/.github/workflows/tests-build.yml
@@ -39,6 +39,8 @@ jobs:
         run: yarn install
       - name: Create Build
         run: yarn build
+      - name: Add Typescript Support
+        run: yarn tsc
       - name: Create Package
         run: yarn pack
       - name: Archive Package


### PR DESCRIPTION
Added workflow step to run "yarn tsc" command while building package. which will add typescript declaration files to each modules and will make it easy to be accessed inside any typescript projects.