### PR TITLE
[dev] Spread all passed props in Link and add closeButtonTestId prop in bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.0.48
 
 - Link - Spread all props on touchable component
+- Bottom Sheet - Add closeButtonTestId prop
 
 --
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v0.0.48
+
+- Link - Spread all props on touchable component
+
+--
+
 ### v0.0.47
 
 - Add Group card list item component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-mobile-app-ui",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/src/modules/bottom-sheet/bottom-sheet.tsx
+++ b/src/modules/bottom-sheet/bottom-sheet.tsx
@@ -71,6 +71,7 @@ export const BottomSheet: React.FC<IProps> = ({
   isOpen,
   onDismiss,
   showCloseButton = true,
+  closeButtonTestId = 'bottom-sheet-close-button',
   children,
   header,
   footer,
@@ -111,6 +112,7 @@ export const BottomSheet: React.FC<IProps> = ({
             <StyledCloseWrapper
               activeOpacity={0.75}
               hitSlop={LayoutUtils.addHitSlop(12)}
+              testID={closeButtonTestId}
               onPress={onCloseModal}>
               <Icon type="closeCircle" color="muted" />
             </StyledCloseWrapper>

--- a/src/modules/bottom-sheet/bottom-sheet.types.ts
+++ b/src/modules/bottom-sheet/bottom-sheet.types.ts
@@ -20,6 +20,9 @@ export interface IProps {
   /** If true, renders the close button on top-right corner. */
   showCloseButton?: boolean;
 
+  /** Test ID for the close button. */
+  closeButtonTestId?: string;
+
   /** Header component of the bottom sheet. */
   header?: IHeader;
 

--- a/src/modules/link/link.tsx
+++ b/src/modules/link/link.tsx
@@ -21,6 +21,7 @@ export const Link: React.FC<IProps> = ({
   color = 'primaryLight',
   small,
   to,
+  ...props
 }): React.ReactElement => {
   // On Link Press
   const onLinkPress = async () => {
@@ -55,7 +56,8 @@ export const Link: React.FC<IProps> = ({
       activeOpacity={0.75}
       onPress={onLinkPress}
       disabled={disabled}
-      testID="link">
+      testID="link"
+      {...props}>
       {label ? (
         <Text color={color} small={small} weight="semiBold" testID="link-label">
           {label}


### PR DESCRIPTION
&lt;Link /&gt;
spread all passed props on the link component. For example, a custom testID prop can be specified now with this change.

&lt;BottomSheet /&gt;
add closeButtonTestId prop to pass a testID to the close button