### PR TITLE
[dev] AB#82299 - Metrics - Filters- Make Secondary screen Top Header sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
+### v0.0.50
 
+- Filter Drawer - Added prop to make header sticky for secondary screen 
+- Filter Drawer - Added Layout prop to get layout information for secondary screen
+
+--
 ### v0.0.49
 
 - Group list item - Fix font weight when inversed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-mobile-app-ui",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/src/modules/filter-drawer/filter-drawer.tsx
+++ b/src/modules/filter-drawer/filter-drawer.tsx
@@ -312,7 +312,9 @@ export const FilterDrawer: React.FC<IProps> = ({
             style={{transform: [{translateX: contentWrapperTranslateX}]}}>
             {/* Secondary Content */}
             <SecondaryContentWrapper testID="drawer-secondary-content">
-              <ScrollView showsVerticalScrollIndicator={false} onLayout={onLayout} >
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                onLayout={onLayout}>
                 {/* Header */}
                 <Header.Wrapper>
                   <Animated.View

--- a/src/modules/filter-drawer/filter-drawer.tsx
+++ b/src/modules/filter-drawer/filter-drawer.tsx
@@ -112,6 +112,8 @@ export const FilterDrawer: React.FC<IProps> = ({
   onRequestClose,
   filterButtonLabel = 'Apply Filters',
   headerTitle = 'Filters',
+  onLayout,
+  stickySecondaryHeader = false,
 }): React.ReactElement => {
   // Refs
   const modalRef = React.useRef(null);
@@ -310,7 +312,7 @@ export const FilterDrawer: React.FC<IProps> = ({
             style={{transform: [{translateX: contentWrapperTranslateX}]}}>
             {/* Secondary Content */}
             <SecondaryContentWrapper testID="drawer-secondary-content">
-              <ScrollView showsVerticalScrollIndicator={false}>
+              <ScrollView showsVerticalScrollIndicator={false} onLayout={onLayout} >
                 {/* Header */}
                 <Header.Wrapper>
                   <Animated.View
@@ -331,9 +333,9 @@ export const FilterDrawer: React.FC<IProps> = ({
                     </Header.BackAction>
                   </Animated.View>
                 </Header.Wrapper>
-
-                {secondaryChildren}
+                {!stickySecondaryHeader ? secondaryChildren : null}
               </ScrollView>
+              {stickySecondaryHeader ? secondaryChildren : null}
             </SecondaryContentWrapper>
           </AnimatedWrapper>
         </SectionWrapper>

--- a/src/modules/filter-drawer/filter-drawer.types.ts
+++ b/src/modules/filter-drawer/filter-drawer.types.ts
@@ -1,3 +1,5 @@
+import {LayoutChangeEvent} from 'react-native';
+
 // Interfaces
 export interface IProps {
   /** Function to be called when "Cancel" button is pressed. */
@@ -46,4 +48,10 @@ export interface IProps {
 
   /** Title to be shown on the header. */
   headerTitle?: string;
+
+  /** Function to be called when "secondary screen is" mounted. */
+  onLayout: ((event: LayoutChangeEvent) => void) | undefined;
+
+  /** Boolean indicating whether secondary header needs to be sticky at top. */
+  stickySecondaryHeader: boolean;
 }


### PR DESCRIPTION
[Bug 82299](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/82299): [Metrics][Filters] - Campus back button, is not sticky or not stayed on the top, when scroll up and down