### PR TITLE
[dev] AB#96801: UI/UX - Update Global component CompactCardList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### v0.0.66
+
+- CompactCardListItem - Added `useShrinkExpandIcon` prop to change default icon chevronUp/Down to shrink/expand
 
 ### v0.0.65
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-mobile-app-ui",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/src/modules/compact-card-list/compact-card-list-item.tsx
+++ b/src/modules/compact-card-list/compact-card-list-item.tsx
@@ -136,6 +136,7 @@ export const CompactCardListItem: React.FC<IProps> = ({
   expandedElement,
   title,
   redMarker,
+  useShrinkExpandIcon = false,
 }): React.ReactElement => {
   // State
   const [isCardExpanded, setCardExpanded] = React.useState<boolean>(false);
@@ -148,6 +149,13 @@ export const CompactCardListItem: React.FC<IProps> = ({
   React.useEffect(() => {
     setCardExpanded(false);
   }, []);
+
+  const _getRightIcon = () => {
+    if (isCardExpanded) {
+      return useShrinkExpandIcon ? 'shrink' : 'chevronUp';
+    }
+    return useShrinkExpandIcon ? 'expand' : 'chevronDown';
+  };
 
   return (
     <StyledWrapper testID={'compact-card'}>
@@ -210,10 +218,7 @@ export const CompactCardListItem: React.FC<IProps> = ({
           )}
           {expandedElement && (
             <StyledExpandLink onPress={() => _onToggle()}>
-              <Icon
-                type={isCardExpanded ? 'chevronUp' : 'chevronDown'}
-                size={16}
-              />
+              <Icon type={_getRightIcon()} size={16} />
             </StyledExpandLink>
           )}
         </StyledSubWrapper>

--- a/src/modules/compact-card-list/compact-card-list-item.types.ts
+++ b/src/modules/compact-card-list/compact-card-list-item.types.ts
@@ -87,4 +87,7 @@ export type IProps = {
 
   /** on press event of Card */
   onPress?: ((event: GestureResponderEvent) => void) | undefined;
+
+  /** get shrink and expand icon at the place of chevronUp and chevronDown */
+  useShrinkExpandIcon?: boolean;
 };


### PR DESCRIPTION
[Task 96801](https://dev.azure.com/saddlebackchurch/Church%20Management/_workitems/edit/96801): UI/UX - Update Global component CompactCardList to add expand shrink icon

Added a prop to switch between chevron and expand/Shrink icon

![image](https://github.com/saddlebackdev/hc-mobile-app-ui/assets/112999344/c1381486-3110-4b91-be6f-417ba81b6914)
