### PR TITLE
fix: move testID/accessibilityLabel from the source element to the wrapping view element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
+### v0.0.77
+
+- Move testID/accessibilityLabel from the source element to the wrapping view element
+
+---
+
 ### v0.0.76
 
 - Checkbox - Allow adding testID and accessibilityLabel as props
 - Pill Toggle - Allow adding testID and accessibilityLabel as props
 - Radio - Allow adding testID and accessibilityLabel as props
+
+---
 
 ### v0.0.75
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-mobile-app-ui",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/src/modules/card-list/__tests__/__snapshots__/card-list-item.test.tsx.snap
+++ b/src/modules/card-list/__tests__/__snapshots__/card-list-item.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`CardListItem Interactions should call onPress method when pressed 1`] = `
 <View
-  accessible={true}
+  accessibilityLabel="list-item"
+  accessible={false}
   collapsable={false}
   focusable={true}
   nativeID="animatedComponent"
@@ -32,6 +33,7 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
     }
   >
     <View
+      accessibilityLabel="item-photo"
       style={
         Array [
           Object {
@@ -39,6 +41,7 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
           },
         ]
       }
+      testID="item-photo"
     >
       <Image
         source={
@@ -55,7 +58,6 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
             },
           ]
         }
-        testID="item-photo"
       />
     </View>
     <View
@@ -68,11 +70,13 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
       }
     >
       <View
+        accessibilityLabel="item-title"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-title"
       >
         <Text
           style={
@@ -86,7 +90,7 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
               },
             ]
           }
-          testID="item-title"
+          testID="heading"
           variant="h4"
         >
           A Title
@@ -105,7 +109,7 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
               },
             ]
           }
-          testID="item-subtitle"
+          testID="text"
           variant="subtitle2"
         >
           A Subtitle
@@ -153,11 +157,13 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
         </Text>
       </View>
       <View
+        accessibilityLabel="item-description"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-description"
       >
         <Text
           muted={true}
@@ -175,18 +181,20 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
               },
             ]
           }
-          testID="item-description"
+          testID="text"
           variant="subtitle2"
         >
           A Description
         </Text>
       </View>
       <View
+        accessibilityLabel="item-tags"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-tags"
       >
         <Text
           italic={true}
@@ -204,7 +212,7 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
               },
             ]
           }
-          testID="item-tags"
+          testID="text"
           variant="subtitle2"
           weight="bold"
         >
@@ -219,7 +227,8 @@ exports[`CardListItem Interactions should call onPress method when pressed 1`] =
 
 exports[`CardListItem Rendering hides tags when it is null 1`] = `
 <View
-  accessible={true}
+  accessibilityLabel="list-item"
+  accessible={false}
   collapsable={false}
   focusable={true}
   nativeID="animatedComponent"
@@ -249,6 +258,7 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
     }
   >
     <View
+      accessibilityLabel="item-photo"
       style={
         Array [
           Object {
@@ -256,6 +266,7 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
           },
         ]
       }
+      testID="item-photo"
     >
       <Image
         source={
@@ -272,7 +283,6 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
             },
           ]
         }
-        testID="item-photo"
       />
     </View>
     <View
@@ -285,11 +295,13 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
       }
     >
       <View
+        accessibilityLabel="item-title"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-title"
       >
         <Text
           style={
@@ -303,7 +315,7 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
               },
             ]
           }
-          testID="item-title"
+          testID="heading"
           variant="h4"
         >
           A Title
@@ -322,7 +334,7 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
               },
             ]
           }
-          testID="item-subtitle"
+          testID="text"
           variant="subtitle2"
         >
           A Subtitle
@@ -370,11 +382,13 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="item-description"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-description"
       >
         <Text
           muted={true}
@@ -392,7 +406,7 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
               },
             ]
           }
-          testID="item-description"
+          testID="text"
           variant="subtitle2"
         >
           A Description
@@ -405,7 +419,8 @@ exports[`CardListItem Rendering hides tags when it is null 1`] = `
 
 exports[`CardListItem Rendering renders itself correctly 1`] = `
 <View
-  accessible={true}
+  accessibilityLabel="list-item"
+  accessible={false}
   collapsable={false}
   focusable={true}
   nativeID="animatedComponent"
@@ -435,6 +450,7 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
     }
   >
     <View
+      accessibilityLabel="item-photo"
       style={
         Array [
           Object {
@@ -442,6 +458,7 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
           },
         ]
       }
+      testID="item-photo"
     >
       <Image
         source={
@@ -458,7 +475,6 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
             },
           ]
         }
-        testID="item-photo"
       />
     </View>
     <View
@@ -471,11 +487,13 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
       }
     >
       <View
+        accessibilityLabel="item-title"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-title"
       >
         <Text
           style={
@@ -489,7 +507,7 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
               },
             ]
           }
-          testID="item-title"
+          testID="heading"
           variant="h4"
         >
           A Title
@@ -508,7 +526,7 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
               },
             ]
           }
-          testID="item-subtitle"
+          testID="text"
           variant="subtitle2"
         >
           A Subtitle
@@ -556,11 +574,13 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="item-description"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-description"
       >
         <Text
           muted={true}
@@ -578,18 +598,20 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
               },
             ]
           }
-          testID="item-description"
+          testID="text"
           variant="subtitle2"
         >
           A Description
         </Text>
       </View>
       <View
+        accessibilityLabel="item-tags"
         style={
           Array [
             Object {},
           ]
         }
+        testID="item-tags"
       >
         <Text
           italic={true}
@@ -607,7 +629,7 @@ exports[`CardListItem Rendering renders itself correctly 1`] = `
               },
             ]
           }
-          testID="item-tags"
+          testID="text"
           variant="subtitle2"
           weight="bold"
         >

--- a/src/modules/card-list/__tests__/__snapshots__/card-list.test.tsx.snap
+++ b/src/modules/card-list/__tests__/__snapshots__/card-list.test.tsx.snap
@@ -60,7 +60,8 @@ exports[`CardList Rendering renders itself correctly 1`] = `
       style={null}
     >
       <View
-        accessible={true}
+        accessibilityLabel="list-item"
+        accessible={false}
         collapsable={false}
         focusable={true}
         nativeID="animatedComponent"
@@ -90,6 +91,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
           }
         >
           <View
+            accessibilityLabel="item-photo"
             style={
               Array [
                 Object {
@@ -97,6 +99,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                 },
               ]
             }
+            testID="item-photo"
           >
             <Image
               source={
@@ -113,7 +116,6 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                   },
                 ]
               }
-              testID="item-photo"
             />
           </View>
           <View
@@ -126,11 +128,13 @@ exports[`CardList Rendering renders itself correctly 1`] = `
             }
           >
             <View
+              accessibilityLabel="item-title"
               style={
                 Array [
                   Object {},
                 ]
               }
+              testID="item-title"
             >
               <Text
                 style={
@@ -144,7 +148,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-title"
+                testID="heading"
                 variant="h4"
               >
                 A Title
@@ -163,18 +167,20 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-subtitle"
+                testID="text"
                 variant="subtitle2"
               >
                 A Subtitle
               </Text>
             </View>
             <View
+              accessibilityLabel="item-description"
               style={
                 Array [
                   Object {},
                 ]
               }
+              testID="item-description"
             >
               <Text
                 muted={true}
@@ -192,18 +198,20 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-description"
+                testID="text"
                 variant="subtitle2"
               >
                 A Description
               </Text>
             </View>
             <View
+              accessibilityLabel="item-tags"
               style={
                 Array [
                   Object {},
                 ]
               }
+              testID="item-tags"
             >
               <Text
                 italic={true}
@@ -221,7 +229,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-tags"
+                testID="text"
                 variant="subtitle2"
                 weight="bold"
               >
@@ -250,7 +258,8 @@ exports[`CardList Rendering renders itself correctly 1`] = `
       style={null}
     >
       <View
-        accessible={true}
+        accessibilityLabel="list-item"
+        accessible={false}
         collapsable={false}
         focusable={true}
         nativeID="animatedComponent"
@@ -280,6 +289,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
           }
         >
           <View
+            accessibilityLabel="item-photo"
             style={
               Array [
                 Object {
@@ -287,6 +297,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                 },
               ]
             }
+            testID="item-photo"
           >
             <Image
               source={
@@ -303,7 +314,6 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                   },
                 ]
               }
-              testID="item-photo"
             />
           </View>
           <View
@@ -316,11 +326,13 @@ exports[`CardList Rendering renders itself correctly 1`] = `
             }
           >
             <View
+              accessibilityLabel="item-title"
               style={
                 Array [
                   Object {},
                 ]
               }
+              testID="item-title"
             >
               <Text
                 style={
@@ -334,7 +346,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-title"
+                testID="heading"
                 variant="h4"
               >
                 A Title
@@ -353,18 +365,20 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-subtitle"
+                testID="text"
                 variant="subtitle2"
               >
                 A Subtitle
               </Text>
             </View>
             <View
+              accessibilityLabel="item-description"
               style={
                 Array [
                   Object {},
                 ]
               }
+              testID="item-description"
             >
               <Text
                 muted={true}
@@ -382,7 +396,7 @@ exports[`CardList Rendering renders itself correctly 1`] = `
                     },
                   ]
                 }
-                testID="item-description"
+                testID="text"
                 variant="subtitle2"
               >
                 A Description

--- a/src/modules/card-list/card-list-item.tsx
+++ b/src/modules/card-list/card-list-item.tsx
@@ -87,13 +87,9 @@ export const CardListItem: React.FC<IProps> = ({
           <StyledCardDetailsRow
             testID="item-title"
             accessibilityLabel="item-title">
-            <StyledTitle variant="h4">
-              {title}
-            </StyledTitle>
+            <StyledTitle variant="h4">{title}</StyledTitle>
             {subTitle ? (
-              <StyledSubTitle variant="subtitle2">
-                {subTitle}
-              </StyledSubTitle>
+              <StyledSubTitle variant="subtitle2">{subTitle}</StyledSubTitle>
             ) : null}
             {eventDate ? (
               <StyledDate
@@ -117,8 +113,7 @@ export const CardListItem: React.FC<IProps> = ({
             <StyledCardDetailsRow
               testID="item-description"
               accessibilityLabel="item-description">
-              <StyledDescription numberOfLines={2} variant="subtitle2"
-                muted>
+              <StyledDescription numberOfLines={2} variant="subtitle2" muted>
                 {description}
               </StyledDescription>
             </StyledCardDetailsRow>
@@ -128,8 +123,7 @@ export const CardListItem: React.FC<IProps> = ({
               testID="item-tags"
               accessibilityLabel="item-tags">
               <StyledTags
-                muted italic variant="subtitle2"
-                weight="bold">
+                muted italic variant="subtitle2" weight="bold">
                 {tags.map((tag, ndx) => {
                   const isLastChild = tags.length - 1 === ndx;
 

--- a/src/modules/card-list/card-list-item.tsx
+++ b/src/modules/card-list/card-list-item.tsx
@@ -122,8 +122,7 @@ export const CardListItem: React.FC<IProps> = ({
             <StyledCardDetailsRow
               testID="item-tags"
               accessibilityLabel="item-tags">
-              <StyledTags
-                muted italic variant="subtitle2" weight="bold">
+              <StyledTags muted italic variant="subtitle2" weight="bold">
                 {tags.map((tag, ndx) => {
                   const isLastChild = tags.length - 1 === ndx;
 

--- a/src/modules/card-list/card-list-item.tsx
+++ b/src/modules/card-list/card-list-item.tsx
@@ -67,9 +67,16 @@ export const CardListItem: React.FC<IProps> = ({
   onPress,
 }): React.ReactElement => (
   <React.Fragment>
-    <StyledCard activeOpacity={0.75} onPress={onPress} testID="list-item" accessibilityLabel="list-item" accessible={false}>
+    <StyledCard
+      activeOpacity={0.75}
+      onPress={onPress}
+      testID="list-item"
+      accessibilityLabel="list-item"
+      accessible={false}>
       <StyledCardContent>
-        <StyledCardPhotoWrapper testID="item-photo" accessibilityLabel="item-photo">
+        <StyledCardPhotoWrapper
+          testID="item-photo"
+          accessibilityLabel="item-photo">
           <StyledPhoto
             source={photoUrl ? {uri: photoUrl} : fallbackImage}
             defaultSource={placeHolderImage}
@@ -77,7 +84,9 @@ export const CardListItem: React.FC<IProps> = ({
           />
         </StyledCardPhotoWrapper>
         <StyledCardDetailsWrapper>
-          <StyledCardDetailsRow testID="item-title" accessibilityLabel="item-title">
+          <StyledCardDetailsRow
+            testID="item-title"
+            accessibilityLabel="item-title">
             <StyledTitle variant="h4">
               {title}
             </StyledTitle>
@@ -105,21 +114,21 @@ export const CardListItem: React.FC<IProps> = ({
             ) : null}
           </StyledCardDetailsRow>
           {description ? (
-            <StyledCardDetailsRow testID="item-description" accessibilityLabel="item-description">
-              <StyledDescription
-                numberOfLines={2}
-                variant="subtitle2"
+            <StyledCardDetailsRow
+              testID="item-description"
+              accessibilityLabel="item-description">
+              <StyledDescription numberOfLines={2} variant="subtitle2"
                 muted>
                 {description}
               </StyledDescription>
             </StyledCardDetailsRow>
           ) : null}
           {tags ? (
-            <StyledCardDetailsRow testID="item-tags" accessibilityLabel="item-tags">
+            <StyledCardDetailsRow
+              testID="item-tags"
+              accessibilityLabel="item-tags">
               <StyledTags
-                muted
-                italic
-                variant="subtitle2"
+                muted italic variant="subtitle2"
                 weight="bold">
                 {tags.map((tag, ndx) => {
                   const isLastChild = tags.length - 1 === ndx;

--- a/src/modules/card-list/card-list-item.tsx
+++ b/src/modules/card-list/card-list-item.tsx
@@ -67,23 +67,22 @@ export const CardListItem: React.FC<IProps> = ({
   onPress,
 }): React.ReactElement => (
   <React.Fragment>
-    <StyledCard activeOpacity={0.75} onPress={onPress} testID="list-item">
+    <StyledCard activeOpacity={0.75} onPress={onPress} testID="list-item" accessibilityLabel="list-item" accessible={false}>
       <StyledCardContent>
-        <StyledCardPhotoWrapper>
+        <StyledCardPhotoWrapper testID="item-photo" accessibilityLabel="item-photo">
           <StyledPhoto
             source={photoUrl ? {uri: photoUrl} : fallbackImage}
             defaultSource={placeHolderImage}
-            testID="item-photo"
             $radius={radius}
           />
         </StyledCardPhotoWrapper>
         <StyledCardDetailsWrapper>
-          <StyledCardDetailsRow>
-            <StyledTitle variant="h4" testID="item-title">
+          <StyledCardDetailsRow testID="item-title" accessibilityLabel="item-title">
+            <StyledTitle variant="h4">
               {title}
             </StyledTitle>
             {subTitle ? (
-              <StyledSubTitle variant="subtitle2" testID="item-subtitle">
+              <StyledSubTitle variant="subtitle2">
                 {subTitle}
               </StyledSubTitle>
             ) : null}
@@ -106,24 +105,22 @@ export const CardListItem: React.FC<IProps> = ({
             ) : null}
           </StyledCardDetailsRow>
           {description ? (
-            <StyledCardDetailsRow>
+            <StyledCardDetailsRow testID="item-description" accessibilityLabel="item-description">
               <StyledDescription
                 numberOfLines={2}
                 variant="subtitle2"
-                muted
-                testID="item-description">
+                muted>
                 {description}
               </StyledDescription>
             </StyledCardDetailsRow>
           ) : null}
           {tags ? (
-            <StyledCardDetailsRow>
+            <StyledCardDetailsRow testID="item-tags" accessibilityLabel="item-tags">
               <StyledTags
                 muted
                 italic
                 variant="subtitle2"
-                weight="bold"
-                testID="item-tags">
+                weight="bold">
                 {tags.map((tag, ndx) => {
                   const isLastChild = tags.length - 1 === ndx;
 


### PR DESCRIPTION
…Also, disable accessible flag on the parent card level

This is in support of the automation efforts to be able to see the test ID and the actual value of the elements (e.g. title, description, tags, etc)